### PR TITLE
Update android image server location

### DIFF
--- a/Gentoo/app-emulation/qemu-android-x86-nougat/qemu-android-x86-nougat-9999.ebuild
+++ b/Gentoo/app-emulation/qemu-android-x86-nougat/qemu-android-x86-nougat-9999.ebuild
@@ -7,7 +7,7 @@ inherit rpm git-r3 xdg-utils
 
 DESCRIPTION="Android-x86 environment via QEMU and VirGL"
 HOMEPAGE="https://github.com/viperML/qemu-android-x86"
-SRC_URI="https://osdn.mirror.constant.com//android-x86/67834/android-x86-7.1-r5.x86_64.rpm"
+SRC_URI="https://osdn.mirror.constant.com//android-x86/71931/android-x86-7.1-r5.x86_64.rpm"
 EGIT_REPO_URI="https://github.com/viperML/qemu-android-x86.git"
 EGIT_BRANCH="testing"
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@ optdepends=(
     'rxvt-unicode: for GUI support'
     'zenity: for GUI support')
 install="qemu-android-x86.install"
-source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.mirror.constant.com//android-x86/67834/android-x86-${_pkgver}.${arch}.rpm"
+source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.mirror.constant.com//android-x86/71931/android-x86-${_pkgver}.${arch}.rpm"
 		"qemu-android.svg"
 		"qemu-android"
 		"config"


### PR DESCRIPTION
The old server location returns 404, the 67834 folder only includes android 7

https://osdn.mirror.constant.com/android-x86/67834/